### PR TITLE
Added a link to the course website to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # TIF285 Learning from data
 This repository and website contains the syllabus, lecture notes, and course materials
 for the Chalmers course "Learning from data" in the Physics MSc program.
+
+The course website can be accessed at: https://physics-chalmers.github.io/tif285/doc/web/


### PR DESCRIPTION
I added a link to the course website on the README file to make it easier for someone to go there when the check out the repository in Github.

