### PR TITLE
Update TIF285_exercise_Jupyter_Python_intro_01.ipynb

### DIFF
--- a/doc/pub/Exercises/Week1/TIF285_exercise_Jupyter_Python_intro_01.ipynb
+++ b/doc/pub/Exercises/Week1/TIF285_exercise_Jupyter_Python_intro_01.ipynb
@@ -808,7 +808,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can continue this was by printing out other columns or rows. The example here prints out the second column"
+    "We can continue this was by printing out other columns or rows. The example here prints out the second row"
    ]
   },
   {
@@ -818,7 +818,7 @@
    "outputs": [],
    "source": [
     "A = np.log(np.array([ [4.0, 7.0, 8.0], [3.0, 10.0, 11.0], [4.0, 5.0, 7.0] ]))\n",
-    "# print the first column, row-major order and elements start with 0\n",
+    "# print the second row, row-major order and elements start with 0\n",
     "print(A[1,:])"
    ]
   },


### PR DESCRIPTION
The second example about printing parts of a matrix claims it prints the second/first column when it in fact prints the second row. Changed so the description match.